### PR TITLE
chore: add skipStatusChecks to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":skipStatusChecks"
   ],
   "automerge": true,
   "major": {


### PR DESCRIPTION
This repository has no tests defined, and by default Renovate holds off for 24 hours on automerging PRs with no status checks in case the CI has an extended outage. Adding this preset will mean that Renovate automerges PRs without waiting on any status checks.