### PR TITLE
add instructions to ensure the user has the right endpoint

### DIFF
--- a/advanced/README.md
+++ b/advanced/README.md
@@ -35,6 +35,8 @@ cd my-app
 # Deploy the Graphcool database
 graphcool deploy
 
+# Confirm that GraphQL endpoint matches `GRAPHCOOL_ENDPOINT` in `.env`
+
 # Start server (runs on http://localhost:4000)
 yarn start
 

--- a/advanced/install.js
+++ b/advanced/install.js
@@ -12,8 +12,9 @@ Next steps:
 
   1. Change directory: \`cd ${project}\`
   2. Deploy database service: \`graphcool deploy\`
-  3. Start local server: \`yarn start\`
-  4. Open Playground: \`yarn playground\`
+  3. Copy the GraphQL endpoint to \`GRAPHCOOL_ENDPOINT\` in the \`.env\` file
+  4. Start local server: \`yarn start\`
+  5. Open Playground: \`yarn playground\`
   `)
 }
 

--- a/advanced/src/index.js
+++ b/advanced/src/index.js
@@ -15,4 +15,4 @@ const server = new GraphQLServer({
   }),
 })
 
-server.start(() => console.log('Server is running on http://localhost:4000'))
+server.start(({ port }) => console.log('Server is running on http://localhost:' + port))

--- a/basic/README.md
+++ b/basic/README.md
@@ -33,6 +33,8 @@ cd my-app
 # Deploy the Graphcool database
 graphcool deploy
 
+# Replace __GRAPHCOOL_ENDPOINT__ and __SERVER_SECRET__ in `src/index.js`
+
 # Start server (runs on http://localhost:4000)
 yarn start
 

--- a/basic/install.js
+++ b/basic/install.js
@@ -11,8 +11,9 @@ Next steps:
 
   1. Change directory: \`cd ${project}\`
   2. Deploy database service: \`graphcool deploy\`
-  3. Start local server: \`yarn start\`
-  4. Open Playground: http://localhost:4000
+  3. Replace __GRAPHCOOL_ENDPOINT__ and __SERVER_SECRET__ in src/index.js
+  4. Start local server: \`yarn start\`
+  5. Open Playground: http://localhost:4000
   `)
 }
 

--- a/basic/src/index.js
+++ b/basic/src/index.js
@@ -34,8 +34,8 @@ const server = new GraphQLServer({
     ...req,
     db: new Graphcool({
       typeDefs: 'src/generated/database.graphql',
-      endpoint: 'http://localhost:60000/graphql-boilerplate/dev',
-      secret: 'mysecret123',
+      endpoint: '__GRAPHCOOL_ENDPOINT__',
+      secret: '__SERVER_SECRET__',
     }),
   }),
 })


### PR DESCRIPTION
Adding explicit instructions to the set up for setting the correct endpoint. It's especially important in the case of the basic version since just following the instructions as they were would result in confusing failure, since the enpoint would presume your app is called 'graphql-boilerplate' instead of 'my-app'. The resulting error message would give little clues about the problem:

`Unexpected token H in JSON at position 0`