### PR TITLE
made the User field in AuthPayload optional

### DIFF
--- a/advanced/src/schema.graphql
+++ b/advanced/src/schema.graphql
@@ -21,7 +21,7 @@ type Subscription {
 
 type AuthPayload {
   token: String!
-  user: User!
+  user: User
 }
 
 type User {


### PR DESCRIPTION
@marktani This should fix this issue
https://github.com/graphql-boilerplates/react-fullstack-graphql/issues/359

* It was happening because User is an Object and was marked as required field in schema of AuthPayload. Now it's made optional
<img width="1440" alt="screen shot 2018-07-04 at 10 30 54 pm" src="https://user-images.githubusercontent.com/4931048/42288781-f34bf5a0-7fd9-11e8-86bb-9c094b4e53d6.png">

Please review.
