### PR TITLE
Update scripts to reflect README

### DIFF
--- a/advanced/package.json
+++ b/advanced/package.json
@@ -4,7 +4,8 @@
     "start": "nodemon -e js,graphql -x node -r dotenv/config src/index.js",
     "debug": "nodemon -e js,graphql -x node --inspect -r dotenv/config src/index.js",
     "playground": "graphql playground",
-    "dev": "npm-run-all --parallel start playground"
+    "dev": "npm-run-all --parallel start playground",
+    "prisma": "prisma"
   },
   "dependencies": {
     "bcryptjs": "2.4.3",


### PR DESCRIPTION
Since there's no `prisma` under scripts you can't follow the README because there is specified `yarn prisma <subcommand>`