### PR TITLE
Fix default value for isPublished

### DIFF
--- a/basic/database/datamodel.graphql
+++ b/basic/database/datamodel.graphql
@@ -1,6 +1,6 @@
 type Post {
   id: ID! @unique
-  isPublished: Boolean! @default(value: false)
+  isPublished: Boolean! @default(value: "false")
   title: String!
   text: String!
 }


### PR DESCRIPTION
All default values should be strings even if the type is Boolean/Float/etc.