### PR TITLE
Chore(README): fix outdated graphql-cli instructions

### DIFF
--- a/advanced/README.md
+++ b/advanced/README.md
@@ -31,9 +31,9 @@ npm install -g graphql-cli
 
 ```sh
 # 1. Bootstrap GraphQL server in directory `my-app`, based on `node-advanced` boilerplate
-graphql create my-app --boilerplate node-advanced
+graphql create my-app
 
-# 2. When prompted, deploy the Prisma service to a _public cluster_
+# 2. When prompted for boilerplate, choose node-advanced
 
 # 3. Navigate to the new project
 cd my-app


### PR DESCRIPTION
Advanced README stated to use `--boilerplate node-advanced`, which is not a valid option with the current graphql-cli. Instead boilerplate is prompted for.

Also there is no prompt regarding deploying the prisma service. See screenshot
![Screenshot at 2020-03-05 09:59:23](https://user-images.githubusercontent.com/2576700/75999579-09da6800-5ec8-11ea-888e-da3cdc7c2ad9.png)

